### PR TITLE
fix: add imageL field in education and experience sections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dileepa.dev",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dileepa.dev",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "@vercel/analytics": "^1.2.2",
         "clsx": "^2.1.0",

--- a/src/constants/textData.ts
+++ b/src/constants/textData.ts
@@ -189,6 +189,7 @@ const educationPageData: EducationPageData = {
       years: "Feb 2024 - Present",
       status: "In Progress",
       image: "nibm",
+      imageL: "nibm",
       link: PageLinks.education.nibm,
     },
     {
@@ -198,6 +199,7 @@ const educationPageData: EducationPageData = {
       years: "Nov 2021 - Feb 2024",
       status: "First Class Honours",
       image: "coventry",
+      imageL: "coventry",
       link: PageLinks.education.coventry,
     },
     {
@@ -207,6 +209,7 @@ const educationPageData: EducationPageData = {
       years: "Apr 2020 - Aug 2021",
       status: "4.0 GPA",
       image: "nibm",
+      imageL: "nibm",
       link: PageLinks.education.nibm,
     },
     {
@@ -216,6 +219,7 @@ const educationPageData: EducationPageData = {
       years: "Mar 2019 - Aug 2020",
       status: "3.75 GPA",
       image: "nibm",
+      imageL: "nibm",
       link: PageLinks.education.nibm,
     },
     {
@@ -225,6 +229,7 @@ const educationPageData: EducationPageData = {
       years: "Jan 2003 - Dec 2016",
       status: "GCE Advanced Level (Maths)",
       image: "mms",
+      imageL: "mms",
       link: PageLinks.education.mms,
     },
   ],
@@ -755,6 +760,7 @@ const experiencePageData: ExperiencePageData = {
       years: "Oct 2022 - Present",
       status: "",
       image: "msft",
+      imageL: "msft",
       link: PageLinks.experience.mlsa,
     },
     {
@@ -764,6 +770,7 @@ const experiencePageData: ExperiencePageData = {
       years: "Jan 2023 - Present",
       status: "",
       image: "mlsa",
+      imageL: "mlsa",
       link: PageLinks.experience.mlsaLK,
     },
     {
@@ -773,6 +780,7 @@ const experiencePageData: ExperiencePageData = {
       years: "Jan 2024 - Present",
       status: "",
       image: "aicsl",
+      imageL: "aicsl",
       link: PageLinks.experience.aicsl,
     },
     {
@@ -782,6 +790,7 @@ const experiencePageData: ExperiencePageData = {
       years: "Jan 2024 - Present",
       status: "",
       image: "mlsc-nibm",
+      imageL: "mlsc-nibm",
       link: PageLinks.experience.mlscnibm,
     },
     {
@@ -791,6 +800,7 @@ const experiencePageData: ExperiencePageData = {
       years: "Jan 2024 - Jun 2024",
       status: "",
       image: "sldf",
+      imageL: "sldf",
       link: PageLinks.experience.sldf,
     },
     {
@@ -800,6 +810,7 @@ const experiencePageData: ExperiencePageData = {
       years: "Oct 2022 - Present",
       status: "",
       image: "gdglk",
+      imageL: "gdglk",
       link: PageLinks.experience.gdgLK,
     },
     {
@@ -809,6 +820,7 @@ const experiencePageData: ExperiencePageData = {
       years: "Oct 2023 - Present",
       status: "",
       image: "fosslk",
+      imageL: "fosslk",
       link: PageLinks.experience.fossLK,
     },
     {
@@ -818,6 +830,7 @@ const experiencePageData: ExperiencePageData = {
       years: "Oct 2022 - Dec 2023",
       status: "",
       image: "nibmcs",
+      imageL: "nibmcs",
       link: PageLinks.experience.nibmcs,
     },
     {
@@ -827,6 +840,7 @@ const experiencePageData: ExperiencePageData = {
       years: "Oct 2022 - Dec 2023",
       status: "",
       image: "nibmfossc",
+      imageL: "nibmfossc",
       link: PageLinks.experience.nibmfossc,
     },
   ],

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -56,6 +56,7 @@ export interface EducationPageData {
     years: string;
     status: string;
     image: string;
+    imageL: string;
     link: string;
   }>;
 }
@@ -127,6 +128,7 @@ export interface ExperiencePageData {
     years: string;
     status: string;
     image: string;
+    imageL: string;
     link: string;
   }>;
 }


### PR DESCRIPTION
**PR Description:**

This PR adds a new imageL field to ensure that icons remain visible when switching to light mode in the Education and Experience sections. Previously, icons would disappear in light mode due to hardcoded image paths or missing light-mode-specific assets.

The changes include:

Adding an imageL field to the data structure for the Education and Experience sections.
Updating the rendering logic to use imageL when in light mode and the existing image field for dark mode.
Including light-mode-specific icons/assets where necessary.

The changes were tested by switching between light and dark modes, and icons are now visible in both themes.

**Screenshots:**
<img width="1440" alt="Screenshot 2025-02-08 at 5 09 02 AM" src="https://github.com/user-attachments/assets/b034e473-d115-4c45-aa3a-46debe09da5d" />
<img width="1440" alt="Screenshot 2025-02-08 at 5 09 13 AM" src="https://github.com/user-attachments/assets/fca720a4-5fa6-456c-b317-12a2310ac407" />
<img width="1434" alt="Screenshot 2025-02-08 at 5 10 34 AM" src="https://github.com/user-attachments/assets/db012143-8680-4cdf-b893-c5efeaf3ceb7" />
<img width="1440" alt="Screenshot 2025-02-08 at 5 11 07 AM" src="https://github.com/user-attachments/assets/2281ecd1-c111-4a3a-93d9-9b3f3556157f" />

Fix: 
<img width="1440" alt="Screenshot 2025-02-08 at 5 12 30 AM" src="https://github.com/user-attachments/assets/89f68c9a-813f-4620-bc21-79d3f905d921" />
<img width="1440" alt="Screenshot 2025-02-08 at 5 12 44 AM" src="https://github.com/user-attachments/assets/a276b8d5-ff7d-4dd3-9eb3-669371a84d1b" />
